### PR TITLE
docs: fix README navigator

### DIFF
--- a/packages/shell/README.md
+++ b/packages/shell/README.md
@@ -1,10 +1,19 @@
 <div align="center">
 
-<span></span>|<span></span>
--|-
-[Lagrange.Core](https://github.com/LagrangeDev/Lagrange.Core)|NTQQ 的协议实现
-[OpenShamrock](https://github.com/whitechi73/OpenShamrock)|基于 Lsposed 实现 OneBot 标准的机器人框架
-[Chronocat](https://github.com/chrononeko/chronocat)|基于 Electron 的、模块化的 Satori 框架（👈你在这里
+<table>
+<tr>
+  <td><a href="https://github.com/LagrangeDev/Lagrange.Core">Lagrange.Core</a></td>
+  <td>NTQQ 的协议实现</td>
+</tr>
+<tr>
+  <td><a href="https://github.com/whitechi73/OpenShamrock">OpenShamrock</a></td>
+  <td>基于 Lsposed 实现 OneBot 标准的机器人框架</td>
+</tr>
+<tr>
+  <td><a href="https://github.com/chrononeko/chronocat">Chronocat</a></td>
+  <td>基于 Electron 的、模块化的 Satori 框架（👈你在这里</td>
+</tr>
+</table>
 
 </div>
 


### PR DESCRIPTION
### Description
Cannot stand that rendering of markdown table with empty header, use raw HTML table instead.

### Validation Cases
  - [x] Manual check rendering on Github after converted to raw HTML.
    ![image](https://github.com/chrononeko/chronocat/assets/41534161/e7649679-b342-4aea-8986-57c3cb75245b)
